### PR TITLE
ignore pipe

### DIFF
--- a/make2json.awk
+++ b/make2json.awk
@@ -8,6 +8,7 @@ function fullpaths(root_orig, paths_wordlist,
     split(paths_wordlist, paths_array)
     for (i in paths_array) {
         path = paths_array[i]
+        if (path == "|") { continue }
         root = gensub(/\/$/, "", "g", root_orig)
         if(match(path, /^\//)) {
             result = result " " path


### PR DESCRIPTION
Hi,

your tool works great, but has problem with [order-only dependencies](https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html). In particular, the pipe (`|`) character in a list of dependencies causes a JS exception, because it does not correspond to a proper target name.

This patch skips pipe characters in the awk script prereqs.